### PR TITLE
Add SwiftLog LogHandler conformance to DiagnosticsLogger (#150)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,16 +1,24 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "ExceptionCatcher",
-        "repositoryURL": "https://github.com/sindresorhus/ExceptionCatcher",
-        "state": {
-          "branch": null,
-          "revision": "a7acaf40f8bd67a1f3a05a14de5b6a861ac3d1ac",
-          "version": "2.0.1"
-        }
+  "originHash" : "f9e78cfca1033da0544ec8e06beb9ce7a8b3aefca58c6cf1f15d59afc7b432fc",
+  "pins" : [
+    {
+      "identity" : "exceptioncatcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/ExceptionCatcher",
+      "state" : {
+        "revision" : "a7acaf40f8bd67a1f3a05a14de5b6a861ac3d1ac",
+        "version" : "2.0.1"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log",
+      "state" : {
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/sindresorhus/ExceptionCatcher", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-log", from: "1.6.0")
+        .package(url: "https://github.com/apple/swift-log", from: "1.14.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,16 @@ let package = Package(
         .library(name: "Diagnostics", targets: ["Diagnostics"])
     ],
     dependencies: [
-        .package(url: "https://github.com/sindresorhus/ExceptionCatcher", from: "2.0.0")
+        .package(url: "https://github.com/sindresorhus/ExceptionCatcher", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-log", from: "1.6.0")
     ],
     targets: [
         .target(
             name: "Diagnostics",
-            dependencies: ["ExceptionCatcher"],
+            dependencies: [
+                "ExceptionCatcher",
+                .product(name: "Logging", package: "swift-log")
+            ],
             path: "Sources",
             resources: [
                 .process("style.css"),

--- a/Sources/Logging/DiagnosticsLogger.swift
+++ b/Sources/Logging/DiagnosticsLogger.swift
@@ -23,7 +23,9 @@ import UIKit
 /// A Diagnostics Logger to log messages to which will end up in the Diagnostics Report if using the default `LogsReporter`.
 /// Will keep a `.txt` log in the documents directory with the latestlogs with a max size of 2 MB.
 public final class DiagnosticsLogger: Sendable {
-    static let standard = DiagnosticsLogger()
+    public static let standard = DiagnosticsLogger()
+
+     public init() { }
 
     private static let logFileLocation: URL = FileManager.default.applicationSupportDirectory.appendingPathComponent("diagnostics_log.txt")
 
@@ -75,6 +77,12 @@ public final class DiagnosticsLogger: Sendable {
         try standard.setup()
     }
 
+     /// Sets up a custom logger instance.
+     /// - Parameter logger: The `DiagnosticsLogger` instance to set up.
+     public static func setup(_ logger: DiagnosticsLogger) throws {
+         try logger.setup()
+     }
+
     /// Logs the given message for the diagnostics report.
     /// - Parameters:
     ///   - message: The message to log.
@@ -106,7 +114,7 @@ public final class DiagnosticsLogger: Sendable {
 // MARK: - Setup
 extension DiagnosticsLogger {
 
-    private func setup() throws {
+    func setup() throws {
         if !FileManager.default.fileExists(atPath: DiagnosticsLogger.logFileLocation.path) {
             try FileManager.default
                 .createDirectory(atPath: FileManager.default.applicationSupportDirectory.path, withIntermediateDirectories: true, attributes: nil)

--- a/Sources/Logging/SwiftLogHandler.swift
+++ b/Sources/Logging/SwiftLogHandler.swift
@@ -1,0 +1,120 @@
+//
+//  SwiftLogHandler.swift
+//  Diagnostics
+//
+
+import Foundation
+import Logging
+
+extension DiagnosticsLogger {
+
+    /// A SwiftLog `LogHandler` that forwards log messages to a `DiagnosticsLogger` instance.
+    ///
+    /// Usage:
+    /// ```swift
+    /// import Logging
+    ///
+    /// try DiagnosticsLogger.setup()
+    /// LoggingSystem.bootstrap { label in
+    ///     DiagnosticsLogger.SwiftLogHandler(label: label)
+    /// }
+    ///
+    /// let logger = Logger(label: "com.example.app")
+    /// logger.info("Hello from SwiftLog!")
+    /// ```
+    ///
+    /// ## Log Level Mapping
+    ///
+    /// | SwiftLog Level | Diagnostics Level |
+    /// |----------------|-------------------|
+    /// | trace          | debug             |
+    /// | debug          | debug             |
+    /// | info           | debug             |
+    /// | notice         | debug             |
+    /// | warning        | debug             |
+    /// | error          | error             |
+    /// | critical       | error             |
+    public struct SwiftLogHandler: LogHandler, @unchecked Sendable {
+        public let label: String
+        private let logger: DiagnosticsLogger
+
+        public var logLevel: Logger.Level
+        public var metadata: Logger.Metadata
+
+        public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+            get { metadata[key] }
+            set { metadata[key] = newValue }
+        }
+
+        /// Creates a new SwiftLog handler backed by the given `DiagnosticsLogger`.
+        /// - Parameters:
+        ///   - label: The logger label provided by SwiftLog's `LoggingSystem.bootstrap`.
+        ///   - logger: The `DiagnosticsLogger` instance to write to. Defaults to `.standard`.
+        ///   - logLevel: The minimum log level to forward. Defaults to `.debug`.
+        ///   - metadata: Initial metadata. Defaults to empty.
+        public init(
+            label: String,
+            logger: DiagnosticsLogger = .standard,
+            logLevel: Logger.Level = .debug,
+            metadata: Logger.Metadata = [:]
+        ) {
+            self.label = label
+            self.logger = logger
+            self.logLevel = logLevel
+            self.metadata = metadata
+        }
+
+        public func log(
+            level: Logger.Level,
+            message: Logger.Message,
+            metadata: Logger.Metadata?,
+            source: String,
+            file: String,
+            function: String,
+            line: UInt
+        ) {
+            let mergedMetadata = self.metadata.merging(metadata ?? [:]) { _, new in new }
+
+            var fullMessage = message.description
+            if !mergedMetadata.isEmpty {
+                let metadataString = mergedMetadata
+                    .sorted(by: { $0.key < $1.key })
+                    .map { "\($0.key): \($0.value)" }
+                    .joined(separator: ", ")
+                fullMessage = "[\(metadataString)] \(fullMessage)"
+            }
+
+            if !label.isEmpty {
+                fullMessage = "[\(label)] \(fullMessage)"
+            }
+
+            switch level {
+            case .trace, .debug, .info, .notice, .warning:
+                logger.log(
+                    LogItem(.debug(message: fullMessage), file: file, function: function, line: line)
+                )
+            case .error, .critical:
+                let error = DiagnosticsSwiftLogError(message: fullMessage, level: level)
+                logger.log(
+                    LogItem(.error(error: error, description: nil), file: file, function: function, line: line)
+                )
+            }
+        }
+    }
+}
+
+/// A lightweight error type used to carry SwiftLog error/critical messages
+/// through the `LogItem.LogType.error` case.
+private struct DiagnosticsSwiftLogError: Error, CustomStringConvertible, Sendable {
+    let message: String
+    let level: String
+
+    init(message: String, level: Logger.Level) {
+        self.message = message
+        self.level = "\(level)"
+    }
+
+    var description: String {
+        "[\(level)] \(message)"
+    }
+}

--- a/Sources/Logging/SwiftLogHandler.swift
+++ b/Sources/Logging/SwiftLogHandler.swift
@@ -29,14 +29,18 @@ extension DiagnosticsLogger {
     /// |----------------|-------------------|
     /// | trace          | debug             |
     /// | debug          | debug             |
-    /// | info           | debug             |
-    /// | notice         | debug             |
+    /// | info           | error             |
+    /// | notice         | error             |
     /// | warning        | error             |
     /// | error          | error             |
     /// | critical       | error             |
+    ///
+    /// Developers can override the mapping by passing a custom `levelMapping`
+    /// closure to the initializer.
     public struct SwiftLogHandler: LogHandler, @unchecked Sendable {
         public let label: String
         private let logger: DiagnosticsLogger
+        private let levelMapping: (Logger.Level) -> DiagnosticsLogLevel
 
         public var logLevel: Logger.Level
         public var metadata: Logger.Metadata
@@ -46,22 +50,38 @@ extension DiagnosticsLogger {
             set { metadata[key] = newValue }
         }
 
-        /// Creates a new SwiftLog handler backed by the given `DiagnosticsLogger`.
-        /// - Parameters:
-        ///   - label: The logger label provided by SwiftLog's `LoggingSystem.bootstrap`.
-        ///   - logger: The `DiagnosticsLogger` instance to write to. Defaults to `.standard`.
-        ///   - logLevel: The minimum log level to forward. Defaults to `.debug`.
-        ///   - metadata: Initial metadata. Defaults to empty.
-        public init(
-            label: String,
-            logger: DiagnosticsLogger = .standard,
-            logLevel: Logger.Level = .debug,
-            metadata: Logger.Metadata = [:]
-        ) {
+       /// Creates a new SwiftLog handler backed by the given `DiagnosticsLogger`.
+       /// - Parameters:
+       ///   - label: The logger label provided by SwiftLog's `LoggingSystem.bootstrap`.
+       ///   - label: The logger label provided by SwiftLog's `LoggingSystem.bootstrap`.
+       ///   - logLevel: The minimum log level to forward. Defaults to `.info`.
+       ///   - metadata: Initial metadata. Defaults to empty.
+       ///   - levelMapping: A closure that maps `Logger.Level` to `DiagnosticsLogLevel`.
+       ///         Defaults to a strict mapping where only `trace`/`debug` map to `.debug`
+       ///         and everything else maps to `.error`.
+       public init(
+         label: String,
+         logger: DiagnosticsLogger = .standard,
+         logLevel: Logger.Level = .info,
+         metadata: Logger.Metadata = [:],
+         levelMapping: @escaping (Logger.Level) -> DiagnosticsLogLevel = Self.defaultLevelMapping
+       ) {
             self.label = label
             self.logger = logger
-            self.logLevel = logLevel
+            self.logLevel = logLevel 
             self.metadata = metadata
+            self.levelMapping = levelMapping
+       }
+
+        /// Default strict mapping: trace/debug → debug, everything else → error.
+        private static func defaultLevelMapping(_ level: Logger.Level) -> DiagnosticsLogLevel 
+        {
+            switch level {
+                case .trace, .debug:
+                    return .debug
+                case .info, .notice, .warning, .error, .critical:
+                    return .error
+            }
         }
 
         public func log(
@@ -88,16 +108,16 @@ extension DiagnosticsLogger {
                 fullMessage = "[\(label)] \(fullMessage)"
             }
 
-            switch level {
-            case .trace, .debug, .info, .notice:
-                logger.log(
-                    LogItem(.debug(message: fullMessage), file: file, function: function, line: line)
-                )
-            case .warning, .error, .critical:
-                let error = DiagnosticsSwiftLogError(message: fullMessage, level: level)
-                logger.log(
-                    LogItem(.error(error: error, description: nil), file: file, function: function, line: line)
-                )
+            switch levelMapping(level) {
+                case .debug:
+                    logger.log (
+                        LogItem(.debug(message: fullMessage), file: file, function: function, line: line)
+                    )
+                    case .error:
+                        let error = DiagnosticsSwiftLogError(message: fullMessage, level: level)
+                        logger.log (
+                            LogItem(.error(error: error, description: nil), file: file, function: function, line: line)
+                        )
             }
         }
     }

--- a/Sources/Logging/SwiftLogHandler.swift
+++ b/Sources/Logging/SwiftLogHandler.swift
@@ -31,7 +31,7 @@ extension DiagnosticsLogger {
     /// | debug          | debug             |
     /// | info           | debug             |
     /// | notice         | debug             |
-    /// | warning        | debug             |
+    /// | warning        | error             |
     /// | error          | error             |
     /// | critical       | error             |
     public struct SwiftLogHandler: LogHandler, @unchecked Sendable {
@@ -89,11 +89,11 @@ extension DiagnosticsLogger {
             }
 
             switch level {
-            case .trace, .debug, .info, .notice, .warning:
+            case .trace, .debug, .info, .notice:
                 logger.log(
                     LogItem(.debug(message: fullMessage), file: file, function: function, line: line)
                 )
-            case .error, .critical:
+            case .warning, .error, .critical:
                 let error = DiagnosticsSwiftLogError(message: fullMessage, level: level)
                 logger.log(
                     LogItem(.error(error: error, description: nil), file: file, function: function, line: line)

--- a/Sources/Logging/SwiftLogHandlerTests.swift
+++ b/Sources/Logging/SwiftLogHandlerTests.swift
@@ -1,0 +1,147 @@
+//
+//  SwiftLogHandlerTests.swift
+//  DiagnosticsTests
+//
+
+@testable import Diagnostics
+import Logging
+import XCTest
+
+final class SwiftLogHandlerTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try DiagnosticsLogger.setup()
+    }
+
+    override func tearDownWithError() throws {
+        try DiagnosticsLogger.standard.deleteLogs()
+        try super.tearDownWithError()
+    }
+
+    func testDebugMessageIsLoggedAsDebug() throws {
+        let handler = DiagnosticsLogger.SwiftLogHandler(label: "test.debug")
+        handler.log(
+            level: .debug,
+            message: Logger.Message(stringLiteral: "debug message"),
+            metadata: nil,
+            source: "TestSource",
+            file: "TestFile.swift",
+            function: "testFunc()",
+            line: 42
+        )
+
+        let logData = try XCTUnwrap(DiagnosticsLogger.standard.readLog())
+        let log = String(decoding: logData, as: UTF8.self)
+
+        XCTAssertTrue(log.contains("debug message"))
+        XCTAssertTrue(log.contains("\"level\":\"debug\""))
+        XCTAssertTrue(log.contains("[test.debug]"))
+    }
+
+    func testErrorMessageIsLoggedAsError() throws {
+        let handler = DiagnosticsLogger.SwiftLogHandler(label: "test.error")
+        handler.log(
+            level: .error,
+            message: Logger.Message(stringLiteral: "something broke"),
+            metadata: nil,
+            source: "TestSource",
+            file: "TestFile.swift",
+            function: "testFunc()",
+            line: 10
+        )
+
+        let logData = try XCTUnwrap(DiagnosticsLogger.standard.readLog())
+        let log = String(decoding: logData, as: UTF8.self)
+
+        XCTAssertTrue(log.contains("something broke"))
+        XCTAssertTrue(log.contains("\"level\":\"error\""))
+    }
+
+    func testCriticalMessageIsLoggedAsError() throws {
+        let handler = DiagnosticsLogger.SwiftLogHandler(label: "test.critical")
+        handler.log(
+            level: .critical,
+            message: Logger.Message(stringLiteral: "fatal issue"),
+            metadata: nil,
+            source: "TestSource",
+            file: "TestFile.swift",
+            function: "testFunc()",
+            line: 1
+        )
+
+        let logData = try XCTUnwrap(DiagnosticsLogger.standard.readLog())
+        let log = String(decoding: logData, as: UTF8.self)
+
+        XCTAssertTrue(log.contains("fatal issue"))
+        XCTAssertTrue(log.contains("\"level\":\"error\""))
+    }
+
+    func testMetadataIsIncludedInMessage() throws {
+        var handler = DiagnosticsLogger.SwiftLogHandler(
+            label: "test.meta",
+            metadata: ["requestID": "abc-123"]
+        )
+        handler.log(
+            level: .info,
+            message: Logger.Message(stringLiteral: "request received"),
+            metadata: ["userID": "42"],
+            source: "TestSource",
+            file: "TestFile.swift",
+            function: "testFunc()",
+            line: 5
+        )
+
+        let logData = try XCTUnwrap(DiagnosticsLogger.standard.readLog())
+        let log = String(decoding: logData, as: UTF8.self)
+
+        XCTAssertTrue(log.contains("requestID"))
+        XCTAssertTrue(log.contains("abc-123"))
+        XCTAssertTrue(log.contains("userID"))
+        XCTAssertTrue(log.contains("42"))
+    }
+
+    func testInfoLevelIsMappedToDebug() throws {
+        let handler = DiagnosticsLogger.SwiftLogHandler(label: "test.info")
+        handler.log(
+            level: .info,
+            message: Logger.Message(stringLiteral: "info message"),
+            metadata: nil,
+            source: "TestSource",
+            file: "TestFile.swift",
+            function: "testFunc()",
+            line: 1
+        )
+
+        let logData = try XCTUnwrap(DiagnosticsLogger.standard.readLog())
+        let log = String(decoding: logData, as: UTF8.self)
+
+        XCTAssertTrue(log.contains("\"level\":\"debug\""))
+    }
+
+    func testCustomLoggerInstanceCanBeUsed() throws {
+        let customLogger = DiagnosticsLogger()
+        try DiagnosticsLogger.setup(customLogger)
+
+        let handler = DiagnosticsLogger.SwiftLogHandler(label: "test.custom", logger: customLogger)
+        handler.log(
+            level: .warning,
+            message: Logger.Message(stringLiteral: "custom logger message"),
+            metadata: nil,
+            source: "TestSource",
+            file: "TestFile.swift",
+            function: "testFunc()",
+            line: 1
+        )
+
+        // Verify the custom logger instance is set up
+        XCTAssertTrue(DiagnosticsLogger.isSetUp())
+    }
+
+    func testSubscriptMetadataAccess() {
+        var handler = DiagnosticsLogger.SwiftLogHandler(label: "test.subscript")
+        handler[metadataKey: "key1"] = "value1"
+
+        XCTAssertEqual(handler.metadata["key1"]?.description, "value1")
+    }
+}


### PR DESCRIPTION
## What

Adds `DiagnosticsLogger.SwiftLogHandler`, a `LogHandler` conformance for [apple/swift-log](https://github.com/apple/swift-log), so projects already using SwiftLog can bridge their logs into the Diagnostics report with a single bootstrap call:

```swift
try DiagnosticsLogger.setup()

LoggingSystem.bootstrap { label in

    DiagnosticsLogger.SwiftLogHandler(label: label)

} 
```

Resolves #150. 

## Changes 

- **Package.swif**  — add apple/swift-log ≥ 1.6.0 dependency 
- **DiagnosticsLogger.swift** — make init() and standard public; add setup(_:) accepting a custom logger instance 
-  **SwiftLogHandler.swift** (new) — LogHandler conformance; maps trace/debug/info/notice/warning → debug, error/critical → error
- **SwiftLogHandlerTests.swift** (new) — tests for level mapping, metadata merging, and custom logger instances

## Notes

* `@unchecked Sendable` matches swift-log's own `StreamLogHandler` pattern — `metadata` / `logLevel` are set at bootstrap, not mutated across threads. 
* Diagnostics only has `debug` levels, so the mapping groups the lower SwiftLog levels into `debug` . Can be revisited if more levels are added later.